### PR TITLE
Update y.go

### DIFF
--- a/y.go
+++ b/y.go
@@ -500,6 +500,9 @@ ipdefault:
 		//line ip.y:54
 		{
 			mask := net.CIDRMask(int(ipDollar[3].num), 32)
+			if mask == nil {
+				mask = net.IPv4Mask(0xff, 0xff, 0xff, 0xff)
+			}
 			min := ipDollar[1].addrRange.Min.Mask(mask)
 			maxInt := binary.BigEndian.Uint32([]byte(min)) +
 				0xffffffff -


### PR DESCRIPTION
If the mask entered by the user is greater than 32, it will return empty when calling net's CIDRMask, causing a panic when the program continues
```
❯ go run main.go
panic: runtime error: index out of range [3] with length 0

goroutine 1 [running]:
encoding/binary.bigEndian.Uint32(...)
        /usr/local/go/src/encoding/binary/binary.go:157
github.com/malfunkt/iprange.(*ipParserImpl).Parse(0x1400012e000, {0x1049143c8?, 0x14000120050?})
        yaccpar:351 +0x14bc
github.com/malfunkt/iprange.ipParse(...)
        yaccpar:153
github.com/malfunkt/iprange.ParseList({0x1048d3770?, 0x140000021a0?})
        ip.y:93 +0xa0
main.main()
        /Users/*/Desktop/sensor/bigdata/waf2/main.go:10 +0x28
exit status 2
```
I made a judgment after calling CIDRMask to generate the mask, and let it be limited to 32, so that when the user enters a value greater than 32, it will be automatically judged as 32. In this way, the program can avoid panic